### PR TITLE
include startup scripts for topcat and stilts

### DIFF
--- a/skaha-containers/software-containers/topcat/Dockerfile
+++ b/skaha-containers/software-containers/topcat/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:30
 # install required software
 RUN dnf makecache -y \
     && dnf update -y \
-    && dnf install -y java-1.8.0-openjdk.x86_64 ca-certificates sudo which xterm sssd-client acl \
+    && dnf install -y java-1.8.0-openjdk.x86_64 ca-certificates sudo which xterm unzip sssd-client acl \
     && dnf clean all \
     && rm -rf /var/cache/yum
 
@@ -16,6 +16,11 @@ RUN touch /etc/sudo.conf && echo "Set disable_coredump false" > /etc/sudo.conf
 # JVM settings
 ENV JAVA_OPTS="-Xms512m -Xmx2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -XX:OnError='cat hs_err_pid%p.log'"
 
-ADD http://www.starlink.ac.uk/topcat/topcat-full.jar /usr/local/bin/topcat-full.jar
-RUN chmod 755 /usr/local/bin/topcat-full.jar
-CMD ["java", "-jar", "/usr/local/bin/topcat-full.jar"]
+# This grabs the most recent TOPCAT/STILTS release.
+# For fixed versions you could use ftp://andromeda.star.bris.ac.uk/pub/star/topcat/vX.X/
+ADD http://www.starlink.ac.uk/topcat/topcat-full.jar /usr/bin/topcat-full.jar
+RUN unzip /usr/bin/topcat-full.jar -d /usr/bin topcat stilts
+RUN chmod 755 /usr/bin/topcat /usr/bin/stilts
+
+# Check STILTS version if applicable.
+CMD ["/usr/bin/stilts", "-version"]


### PR DESCRIPTION
I've installed in /usr/bin rather than /usr/local/bin as well,
I don't know if either is more appropriate.
This seems to work locally, but I haven't tested it in the desktop.