### PR TITLE
replace URL for topcat container with versioned one

### DIFF
--- a/skaha-containers/software-containers/topcat/Dockerfile
+++ b/skaha-containers/software-containers/topcat/Dockerfile
@@ -16,9 +16,9 @@ RUN touch /etc/sudo.conf && echo "Set disable_coredump false" > /etc/sudo.conf
 # JVM settings
 ENV JAVA_OPTS="-Xms512m -Xmx2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -XX:OnError='cat hs_err_pid%p.log'"
 
-# This grabs the most recent TOPCAT/STILTS release.
-# For fixed versions you could use ftp://andromeda.star.bris.ac.uk/pub/star/topcat/vX.X/
-ADD http://www.starlink.ac.uk/topcat/topcat-full.jar /usr/bin/topcat-full.jar
+# Acquire a numbered TOPCAT release.
+# This URL is fairly stable, though not guaranteed in the long term.
+ADD http://andromeda.star.bristol.ac.uk/releases/topcat/v4.8/topcat-full.jar /usr/bin/topcat-full.jar
 RUN unzip /usr/bin/topcat-full.jar -d /usr/bin topcat stilts
 RUN chmod 644 /usr/bin/topcat-full.jar
 RUN chmod 755 /usr/bin/topcat /usr/bin/stilts


### PR DESCRIPTION
Previously the versioned URL for topcat release JARs was FTP-only,
which Docker didn't seem to like, so the ADD URL used the
location of the most recent release.  However historical versions
have now been made available over HTTP, so use the versioned
URL for topcat 4.8 instead.

Since the content of the URL is the same as when the container was
built, this change shouldn't make a material change to the
container content.

Note that v4.8 is no longer the most recent release - v4.8-1 is now
available and includes some bugfixes and enhancements so it could
be updated and rebuilt.